### PR TITLE
fix: make CustomerForm CTAs responsive on mobile

### DIFF
--- a/src/components/checkout/CustomerForm.tsx
+++ b/src/components/checkout/CustomerForm.tsx
@@ -271,8 +271,8 @@ const CustomerPaymentForm = () => {
             </div>
 
           </div>
-          <div className="flex items-center justify-center gap-4">
-            <Button type="button" className="w-fit" variant={"secondary"} onClick={handlePrefill}>
+          <div className="flex flex-col md:flex-row items-center justify-center gap-4">
+            <Button type="button" className="w-full md:w-fit" variant={"secondary"} onClick={handlePrefill}>
               Prefill with demo details
             </Button>
             <Button type="submit" className="w-full" disabled={isLoading}>


### PR DESCRIPTION
Fixed mobile responsiveness for Customer Form CTA's


| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/03c8df9c-590e-4210-8368-f292e570ae00" width="357" /> | <img src="https://github.com/user-attachments/assets/3011341c-8bc2-4625-adb9-db1bf88b529e" width="357" /> |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive layout of Checkout customer form action buttons.
  * Prefill button now spans full width on small screens for easier tapping.
  * On medium and larger screens, Prefill and Continue/Submit align horizontally for better use of space.
  * Continue/Submit button remains full-width to maintain prominence and consistency.
  * No changes to behavior or workflows; visual and usability enhancement only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->